### PR TITLE
refactored global locks with managed states, and replaced tokio with rocket::tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -71,7 +71,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "bytes"
@@ -186,9 +186,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -393,7 +393,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -584,7 +584,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -976,9 +976,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libm"
@@ -1080,15 +1080,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "tokio",
  "toml",
  "walkdir",
 ]
 
 [[package]]
 name = "mokareads-core"
-version = "0.2.0"
-source = "git+https://github.com/Moka-Reads/MokaReads-Core#6f0e4bcd99a5255695e97450957b3aff78a13816"
+version = "0.4.0"
+source = "git+https://github.com/Moka-Reads/MokaReads-Core#da92e45c5878c0ef07582cacfc48f6d6a0dc1fef"
 dependencies = [
  "chrono",
  "mokareads_macros",
@@ -1104,7 +1103,7 @@ dependencies = [
 [[package]]
 name = "mokareads_macros"
 version = "0.1.0"
-source = "git+https://github.com/Moka-Reads/MokaReads-Core#6f0e4bcd99a5255695e97450957b3aff78a13816"
+source = "git+https://github.com/Moka-Reads/MokaReads-Core#da92e45c5878c0ef07582cacfc48f6d6a0dc1fef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1249,7 +1248,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -1328,7 +1327,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -1368,7 +1367,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -1446,9 +1445,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -1461,7 +1460,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
  "version_check",
  "yansi 1.0.0-rc.1",
 ]
@@ -1553,7 +1552,7 @@ checksum = "7f7473c2cfcf90008193dd0e3e16599455cb601a9fce322b5bb55de799664925"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -1688,7 +1687,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.31",
+ "syn 2.0.35",
  "unicode-xid",
 ]
 
@@ -1845,14 +1844,14 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "itoa",
  "ryu",
@@ -1964,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys 0.48.0",
@@ -2015,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "59bf04c28bee9043ed9ea1e41afc0552288d3aba9c6efdd78903b802926f4879"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2076,7 +2075,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -2143,10 +2142,9 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -2159,7 +2157,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -2257,7 +2255,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
 ]
 
 [[package]]
@@ -2307,9 +2305,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ubyte"
@@ -2403,9 +2401,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -2509,7 +2507,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
  "wasm-bindgen-shared",
 ]
 
@@ -2543,7 +2541,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.31",
+ "syn 2.0.35",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ rocket = { version = "0.5.0-rc.3", features = ["json"] }
 rocket_dyn_templates = { version = "0.1.0-rc.3", features = ["tera"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
-tokio = { version = "1.29.1", features = ["full"] }
 toml = "0.7.6"
 walkdir = "2.3.3"
 mokareads-core = {git = "https://github.com/Moka-Reads/MokaReads-Core"}

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -2,10 +2,13 @@ use std::io::Result;
 use std::path::Path;
 
 use futures::future::join_all;
-use mokareads_core::resources::{article::Article, cheatsheet::Cheatsheet, guide::Guide, Parser, Cacher};
+use mokareads_core::resources::{
+    article::Article, cheatsheet::Cheatsheet, guide::Guide, Cacher, Parser,
+};
 use serde::{Deserialize, Serialize};
-use tokio::fs::read_to_string;
+use rocket::tokio::fs::read_to_string;
 use walkdir::WalkDir;
+use rocket::tokio;
 
 const ARTICLES: &str = "Moka-Articles";
 const CHEATSHEETS: &str = "Moka-Cheatsheets";
@@ -107,7 +110,6 @@ impl Files {
         cheatsheets
     }
 }
-
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ResourceRoutes {

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -1,7 +1,7 @@
 use mokareads_core::Result;
-use std::fmt::Display;
 use reqwest::header;
 use serde::Deserialize;
+use std::fmt::Display;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Platforms {
@@ -87,13 +87,13 @@ pub struct GitHubTag {
 impl GitHubTag {
     pub async fn fetch_tags() -> Result<Vec<String>> {
         let user_agent = header::HeaderValue::from_static("MoKa-Tags");
-        let client = reqwest::Client::builder().default_headers(
-            {
+        let client = reqwest::Client::builder()
+            .default_headers({
                 let mut headers = header::HeaderMap::new();
                 headers.insert(header::USER_AGENT, user_agent);
                 headers
-            }
-        ).build()?;
+            })
+            .build()?;
         let resp = client
             .get("https://api.github.com/repos/Moka-Reads/MoKa-Desktop/tags")
             .send()
@@ -104,17 +104,23 @@ impl GitHubTag {
             return Err(format!("Received a {} from server", resp.status()).into());
         }
 
-        let tags: Vec<GitHubTag> = resp.json().await.map_err(|_| "Failed to deserialize response")?;
+        let tags: Vec<GitHubTag> = resp
+            .json()
+            .await
+            .map_err(|_| "Failed to deserialize response")?;
 
-        let tag_names: Vec<String> = tags.into_iter().map(|tag| tag.name.replace("v", "")).collect();
+        let tag_names: Vec<String> = tags
+            .into_iter()
+            .map(|tag| tag.name.replace("v", ""))
+            .collect();
         Ok(tag_names)
     }
 }
 
 #[test]
-fn test_sort(){
+fn test_sort() {
     let mut versions = vec![Version(0, 0, 1), Version(1, 1, 0), Version(0, 1, 0)];
-    let sorted = vec![Version(0, 0, 1), Version(0, 1, 0),Version(1, 1, 0)];
+    let sorted = vec![Version(0, 0, 1), Version(0, 1, 0), Version(1, 1, 0)];
 
     versions.sort();
     assert_eq!(versions, sorted);

--- a/src/roadmap.rs
+++ b/src/roadmap.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
 use serde::{Deserialize, Serialize};
-use tokio::fs::read_to_string;
+use rocket::tokio::fs::read_to_string;
 
 #[derive(Debug, Deserialize, Serialize, Clone, Eq, PartialEq)]
 pub struct RoadmapItem {


### PR DESCRIPTION
The reason of this pull request is to change the global locks to managed states that could improve multithreaded performance with having them work as request guards instead. 

To improve build time, instead of using `tokio`, I have decided to optimize by utilizing `rocket::tokio`. 

RSS path changed from `resources/moka_articles.rss` to `./moka_articles.rss`